### PR TITLE
Fix bug where history and merging do not work

### DIFF
--- a/Source/GitSourceControlDev/Private/GitSourceControlDevUtils.cpp
+++ b/Source/GitSourceControlDev/Private/GitSourceControlDevUtils.cpp
@@ -863,6 +863,7 @@ bool RunGetHistory(const FString& InPathToGitBinary, const FString& InRepository
 		Parameters.Add(TEXT("--follow")); // follow file renames
 		Parameters.Add(TEXT("--date=raw"));
 		Parameters.Add(TEXT("--name-status")); // relative filename at this revision, preceded by a status character
+		Parameters.Add(TEXT("--pretty=medium")); // make sure format matches expected in ParseLogResults
 		TArray<FString> Files;
 		Files.Add(*InFile);
 		if(bMergeConflict)


### PR DESCRIPTION
The command issued to log for history (and before merging) does not specify format. This will cause a failure if the user has pretty format settings in their gitconfig.