### PR TITLE
LFS Diff Support

### DIFF
--- a/Source/GitSourceControlDev/Private/GitSourceControlDevUtils.cpp
+++ b/Source/GitSourceControlDev/Private/GitSourceControlDevUtils.cpp
@@ -695,12 +695,12 @@ bool RunDumpToFile(const FString& InPathToGitBinary, const FString& InRepository
 			BinaryFileContent.Append(MoveTemp(BinaryData));
 		}
 
-		if (CheckLFSAvaliability(InPathToGitBinary))
-		{
+		BinaryFileContent.Add('\0');
+		FString OutputString;
+		OutputString += FUTF8ToTCHAR((const ANSICHAR*)BinaryFileContent.GetData()).Get();
 
-			BinaryFileContent.Add('\0');
-			FString OutputString;
-			OutputString += FUTF8ToTCHAR((const ANSICHAR*)BinaryFileContent.GetData()).Get();
+		if (CheckLFSAvaliability(InPathToGitBinary) && OutputString.Contains(TEXT("git-lfs")))
+		{		
 
 			const FString SmudgeCommand = "lfs smudge";
 
@@ -740,6 +740,7 @@ bool RunDumpToFile(const FString& InPathToGitBinary, const FString& InRepository
 		}
 		else
 		{
+			BinaryFileContent.RemoveAt(BinaryFileContent.Num() - 1);
 			if (FFileHelper::SaveArrayToFile(BinaryFileContent, *InDumpFileName))
 			{
 				UE_LOG(LogSourceControl, Log, TEXT("Writed '%s' (%d bytes)"), *InDumpFileName, BinaryFileContent.Num());

--- a/Source/GitSourceControlDev/Private/GitSourceControlDevUtils.cpp
+++ b/Source/GitSourceControlDev/Private/GitSourceControlDevUtils.cpp
@@ -8,6 +8,7 @@
 #include "GitSourceControlDevState.h"
 #include "GitSourceControlDevModule.h"
 #include "GitSourceControlDevCommand.h"
+#include "InteractiveProcessChooseWD.h"
 
 #if PLATFORM_LINUX
 #include <sys/ioctl.h>
@@ -630,15 +631,14 @@ bool RunDumpToFile(const FString& InPathToGitBinary, const FString& InRepository
 	bool bResult = false;
 	FString FullCommand;
 
-	if(!InRepositoryRoot.IsEmpty())
+	if (!InRepositoryRoot.IsEmpty())
 	{
 		// Specify the working copy (the root) of the git repository (before the command itself)
 		FullCommand = TEXT("--work-tree=\"");
 		FullCommand += InRepositoryRoot;
 		// and the ".git" subdirectory in it (before the command itself)
 		FullCommand += TEXT("\" --git-dir=\"");
-		FullCommand += InRepositoryRoot;
-		FullCommand += TEXT(".git\" ");
+		FullCommand += FPaths::Combine(*InRepositoryRoot, TEXT(".git\" "));
 	}
 	// then the git command itself
 	FullCommand += TEXT("show ");
@@ -656,35 +656,65 @@ bool RunDumpToFile(const FString& InPathToGitBinary, const FString& InRepository
 	verify(FPlatformProcess::CreatePipe(PipeRead, PipeWrite));
 
 	FProcHandle ProcessHandle = FPlatformProcess::CreateProc(*InPathToGitBinary, *FullCommand, bLaunchDetached, bLaunchHidden, bLaunchReallyHidden, nullptr, 0, nullptr, PipeWrite);
-	if(ProcessHandle.IsValid())
+	if (ProcessHandle.IsValid())
 	{
 		FPlatformProcess::Sleep(0.01);
 
 		TArray<uint8> BinaryFileContent;
-		while(FPlatformProcess::IsProcRunning(ProcessHandle))
+		while (FPlatformProcess::IsProcRunning(ProcessHandle))
 		{
 			TArray<uint8> BinaryData;
 			FPlatformProcess::ReadPipeToArray(PipeRead, BinaryData);
-			if(BinaryData.Num() > 0)
+			if (BinaryData.Num() > 0)
 			{
 				BinaryFileContent.Append(MoveTemp(BinaryData));
 			}
 		}
 		TArray<uint8> BinaryData;
 		FPlatformProcess::ReadPipeToArray(PipeRead, BinaryData);
-		if(BinaryData.Num() > 0)
+		if (BinaryData.Num() > 0)
 		{
 			BinaryFileContent.Append(MoveTemp(BinaryData));
 		}
-		// Save buffer into temp file
-		if(FFileHelper::SaveArrayToFile(BinaryFileContent, *InDumpFileName))
+
+		BinaryFileContent.Add('\0');
+		FString OutputString;
+		OutputString += FUTF8ToTCHAR((const ANSICHAR*)BinaryFileContent.GetData()).Get();
+
+		const FString SmudgeCommand = "lfs smudge";
+
+		FInteractiveProcessChooseWD* SmudgeProcess = new FInteractiveProcessChooseWD(*InPathToGitBinary, *SmudgeCommand, InRepositoryRoot, false, false);
+
+		bool bSmudgeProcessFinished = false;
+
+		SmudgeProcess->OnOutputArray().BindLambda([&](TArray<uint8> Output) {
+			if (FFileHelper::SaveArrayToFile(Output, *InDumpFileName))
+			{
+				UE_LOG(LogSourceControl, Log, TEXT("Writed '%s' (%d bytes)"), *InDumpFileName, Output.Num());
+				bResult = true;
+			}
+			else
+			{
+				UE_LOG(LogSourceControl, Error, TEXT("Could not write %s"), *InDumpFileName);
+			}
+
+			bSmudgeProcessFinished = true;
+		});
+
+		SmudgeProcess->OnCompleted().BindLambda([&](int32 Data, bool Successful)
 		{
-			UE_LOG(LogSourceControl, Log, TEXT("Writed '%s' (%do)"), *InDumpFileName, BinaryFileContent.Num());
-			bResult = true;
-		}
-		else
+			UE_LOG(LogTemp, Warning, TEXT("Interactive Process Completed: %d %s"), Data, Successful ? TEXT("True") : TEXT("False"));
+			delete SmudgeProcess;
+
+			FPlatformProcess::ClosePipe(PipeRead, PipeWrite);
+		});
+
+		SmudgeProcess->Launch();
+		SmudgeProcess->SendWhenReady(OutputString);
+
+		while (!bSmudgeProcessFinished)
 		{
-			UE_LOG(LogSourceControl, Error, TEXT("Could not write %s"), *InDumpFileName);
+			FPlatformProcess::Sleep(0.01);
 		}
 	}
 	else

--- a/Source/GitSourceControlDev/Private/GitSourceControlDevUtils.h
+++ b/Source/GitSourceControlDev/Private/GitSourceControlDevUtils.h
@@ -48,6 +48,13 @@ FString FindGitBinaryPath();
 bool CheckGitAvailability(const FString& InPathToGitBinary);
 
 /**
+* Run a Git lfs "version" command to check the availability of the binary.
+* @param InPathToGitBinary		The path to the Git binary
+* @returns true if the command succeeded and returned no errors
+*/
+bool CheckLFSAvaliability(const FString& InPathToGitBinary);
+
+/**
  * Find the root of the Git repository, looking from the provided path and upward in its parent directories
  * @param InPath				The path to the Game Directory (or any path or file in any git repository)
  * @param OutRepositoryRoot		The path to the root directory of the Git repository if found, else the path to the GameDir

--- a/Source/GitSourceControlDev/Private/InteractiveProcessChooseWD.cpp
+++ b/Source/GitSourceControlDev/Private/InteractiveProcessChooseWD.cpp
@@ -1,0 +1,244 @@
+// Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
+
+#include "GitSourceControlPrivatePCH.h"
+#include "InteractiveProcessChooseWD.h"
+
+static FORCEINLINE bool CreatePipeWrite(void*& ReadPipe, void*& WritePipe)
+{
+#if PLATFORM_WINDOWS
+	SECURITY_ATTRIBUTES Attr = { sizeof(SECURITY_ATTRIBUTES), NULL, true };
+
+	if (!::CreatePipe(&ReadPipe, &WritePipe, &Attr, 0))
+	{
+		return false;
+	}
+
+	if (!::SetHandleInformation(WritePipe, HANDLE_FLAG_INHERIT, 0))
+	{
+		return false;
+	}
+
+	return true;
+#else
+	return FPlatformProcess::CreatePipe(ReadPipe, WritePipe);
+#endif // PLATFORM_WINDOWS
+}
+
+
+DEFINE_LOG_CATEGORY(LogInteractiveProcessChooseWD);
+
+FInteractiveProcessChooseWD::FInteractiveProcessChooseWD(const FString& InURL, const FString& InParams, const FString& InWorkingDir, bool InHidden, bool LongTime)
+	: bCanceling(false)
+	, bHidden(InHidden)
+	, bKillTree(false)
+	, URL(InURL)
+	, Params(InParams)
+	, WorkingDir(InWorkingDir)
+	, ReadPipeParent(nullptr)
+	, WritePipeParent(nullptr)
+	, ReadPipeChild(nullptr)
+	, WritePipeChild(nullptr)
+	, Thread(nullptr)
+	, ReturnCode(0)
+	, StartTime(0)
+	, EndTime(0)
+{
+	if(LongTime == true)
+	{
+		SleepTime = 0.0010f; ///< 10 milliseconds sleep
+	}
+	else
+	{
+		SleepTime = 0.f;
+	}
+}
+
+FInteractiveProcessChooseWD::~FInteractiveProcessChooseWD()
+{
+	if (IsRunning() == true)
+	{
+		Cancel(false);
+		Thread->WaitForCompletion();
+		delete Thread;
+	}
+}
+
+FTimespan FInteractiveProcessChooseWD::GetDuration() const
+{
+	if (IsRunning() == true)
+	{
+		return (FDateTime::UtcNow() - StartTime);
+	}
+
+	return (EndTime - StartTime);
+}
+
+bool FInteractiveProcessChooseWD::Launch()
+{
+	if (IsRunning() == true)
+	{
+		UE_LOG(LogInteractiveProcessChooseWD, Warning, TEXT("The process is already running"));
+		return false;
+	}
+
+	// For reading from child process
+	if (FPlatformProcess::CreatePipe(ReadPipeParent, WritePipeChild) == false)
+	{
+		UE_LOG(LogInteractiveProcessChooseWD, Error, TEXT("Failed to create pipes for parent process"));
+		return false;
+	}
+
+	// For writing to child process
+	if (CreatePipeWrite(ReadPipeChild, WritePipeParent) == false)
+	{
+		UE_LOG(LogInteractiveProcessChooseWD, Error, TEXT("Failed to create pipes for parent process"));
+		return false;
+	}
+
+	ProcessHandle = FPlatformProcess::CreateProc(*URL, *Params, false, bHidden, bHidden, nullptr, 0, *WorkingDir, WritePipeChild, ReadPipeChild);
+
+	if (ProcessHandle.IsValid() == false)
+	{
+		UE_LOG(LogInteractiveProcessChooseWD, Error, TEXT("Failed to create process"));
+		return false;
+	}
+
+	// Creating name for the process
+	static uint32 tempInteractiveProcessIndex = 0;
+	ThreadName = FString::Printf(TEXT("FInteractiveProcess %d"), tempInteractiveProcessIndex);
+	tempInteractiveProcessIndex++;
+
+	Thread = FRunnableThread::Create(this, *ThreadName);
+	if (Thread == nullptr)
+	{
+		UE_LOG(LogInteractiveProcessChooseWD, Error, TEXT("Failed to create process thread!"));
+		return false;
+	}
+
+	UE_LOG(LogInteractiveProcessChooseWD, Log, TEXT("Process creation succesfull %s"), *ThreadName);
+
+	return true;
+}
+
+void FInteractiveProcessChooseWD::ProcessOutput(TArray<uint8> Output)
+{
+	if (Output.Num() > 0)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("ProcessOutput: %i"), Output.Num());
+		OutputArrayDelegate.ExecuteIfBound(Output);
+	}
+
+	/*
+	Output.Append(FTCHARToUTF8('\0'));
+	FString OutputString;
+	OutputString += FUTF8ToTCHAR((const ANSICHAR*)Buffer).Get();
+
+	TArray<FString> LogLines;
+
+	OutputString.ParseIntoArray(LogLines, TEXT("\n"), false);
+
+	for (int32 LogIndex = 0; LogIndex < LogLines.Num(); ++LogIndex)
+	{
+		// Don't accept if it is just an empty string
+		if (LogLines[LogIndex].IsEmpty() == false)
+		{
+			OutputDelegate.ExecuteIfBound(LogLines[LogIndex]);
+			UE_LOG(LogInteractiveProcessChooseWD, Log, TEXT("Child Process  -> %s"), *LogLines[LogIndex]);
+		}
+	}*/
+}
+
+void FInteractiveProcessChooseWD::SendMessageToProcessIf()
+{
+	// If there is not a message
+	if (MessagesToProcess.IsEmpty() == true)
+	{
+		return;
+	}
+
+	if (WritePipeParent == nullptr)
+	{
+		UE_LOG(LogInteractiveProcessChooseWD, Warning, TEXT("WritePipe is not valid"));
+		return;
+	}
+
+	if (ProcessHandle.IsValid() == false)
+	{
+		UE_LOG(LogInteractiveProcessChooseWD, Warning, TEXT("Process handle is not valid"));
+		return;
+	}
+
+	// A string for original message and one for written message
+	FString WrittenMessage, Message;
+	MessagesToProcess.Dequeue(Message);
+
+	FPlatformProcess::WritePipe(WritePipeParent, Message, &WrittenMessage);
+
+	UE_LOG(LogInteractiveProcessChooseWD, Log, TEXT("Parent Process -> Original Message: %s , Written Message: %s"), *Message, *WrittenMessage);
+
+	if (WrittenMessage.Len() == 0)
+	{
+		UE_LOG(LogInteractiveProcessChooseWD, Error, TEXT("Writing message through pipe failed"));
+		return;
+	}
+	else if (Message.Len() > WrittenMessage.Len())
+	{
+		UE_LOG(LogInteractiveProcessChooseWD, Error, TEXT("Writing some part of the message through pipe failed"));
+		return;
+	}
+}
+
+void FInteractiveProcessChooseWD::SendWhenReady(const FString &Message)
+{
+	MessagesToProcess.Enqueue(Message);
+}
+
+// FRunnable interface
+uint32 FInteractiveProcessChooseWD::Run()
+{
+	// control and interact with the process
+	StartTime = FDateTime::UtcNow();
+	{
+		do
+		{
+			FPlatformProcess::Sleep(SleepTime);
+
+			TArray<uint8> Output;
+			FPlatformProcess::ReadPipeToArray(ReadPipeParent, Output);
+			// Read pipe and redirect it to ProcessOutput function
+			ProcessOutput(Output);
+
+			// Write to process if there is a message
+			SendMessageToProcessIf();
+
+			// If wanted to stop program
+			if (bCanceling == true)
+			{
+				FPlatformProcess::TerminateProc(ProcessHandle, bKillTree);
+				CanceledDelegate.ExecuteIfBound();
+
+				UE_LOG(LogInteractiveProcessChooseWD, Log, TEXT("The process is being canceled"));
+
+				return 0;
+			}
+		} while (FPlatformProcess::IsProcRunning(ProcessHandle) == true);
+	}
+
+	// close pipes
+	FPlatformProcess::ClosePipe(ReadPipeParent, WritePipeChild);
+	ReadPipeParent = WritePipeChild = nullptr;
+	FPlatformProcess::ClosePipe(ReadPipeChild, WritePipeParent);
+	ReadPipeChild = WritePipeParent = nullptr;
+
+	// get completion status
+	if (FPlatformProcess::GetProcReturnCode(ProcessHandle, &ReturnCode) == false)
+	{
+		ReturnCode = -1;
+	}
+
+	EndTime = FDateTime::UtcNow();
+
+	CompletedDelegate.ExecuteIfBound(ReturnCode, bCanceling);
+
+	return 0;
+}

--- a/Source/GitSourceControlDev/Private/InteractiveProcessChooseWD.cpp
+++ b/Source/GitSourceControlDev/Private/InteractiveProcessChooseWD.cpp
@@ -1,6 +1,6 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "GitSourceControlPrivatePCH.h"
+#include "GitSourceControlDevPrivatePCH.h"
 #include "InteractiveProcessChooseWD.h"
 
 static FORCEINLINE bool CreatePipeWrite(void*& ReadPipe, void*& WritePipe)

--- a/Source/GitSourceControlDev/Private/InteractiveProcessChooseWD.h
+++ b/Source/GitSourceControlDev/Private/InteractiveProcessChooseWD.h
@@ -1,0 +1,231 @@
+// Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "Runtime/Core/Public/GenericPlatform/GenericPlatformProcess.h"
+#include "Runtime/Core/Public/Misc/Timespan.h"
+#include "Runtime/Core/Public/Containers/Queue.h"
+
+
+DECLARE_LOG_CATEGORY_EXTERN(LogInteractiveProcessChooseWD, Log, All);
+
+/**
+* Declares a delegate that is executed when a interactive process completed.
+*
+* The first parameter is the process return code.
+*/
+DECLARE_DELEGATE_TwoParams(FOnInteractiveProcessCompleted, int32, bool);
+
+/**
+* Declares a delegate that is executed when a interactive process produces output.
+*
+* The first parameter is the produced output.
+*/
+DECLARE_DELEGATE_OneParam(FOnInteractiveProcessOutput, const FString&);
+
+DECLARE_DELEGATE_OneParam(FOnInteractiveProcesOutputArray, TArray<uint8>&)
+
+/**
+* Implements an external process that can be interacted.
+*/
+class FInteractiveProcessChooseWD
+	: public FRunnable
+{
+public:
+
+	/**
+	* Creates a new interactive process.
+	*
+	* @param InURL The URL of the executable to launch.
+	* @param InParams The command line parameters.
+	* @param InHidden Whether the window of the process should be hidden.
+	*/
+	FInteractiveProcessChooseWD(const FString& InURL, const FString& InParams, const FString& InWorkingDir, bool InHidden, bool LongTime = false);
+
+	/** Destructor. */
+	~FInteractiveProcessChooseWD();
+
+	/**
+	* Gets the duration of time that the task has been running.
+	*
+	* @return Time duration.
+	*/
+	FTimespan GetDuration() const;
+
+	/**
+	* Checks whether the process is still running.
+	*
+	* @return true if the process is running, false otherwise.
+	*/
+	bool IsRunning() const
+	{
+		return Thread != nullptr;
+	}
+
+	/**
+	* Launches the process
+	*
+	* @return True if succeed
+	*/
+	bool Launch();
+
+	/**
+	* Returns a delegate that is executed when the process has been canceled.
+	*
+	* @return The delegate.
+	*/
+	FSimpleDelegate& OnCanceled()
+	{
+		return CanceledDelegate;
+	}
+
+	/**
+	* Returns a delegate that is executed when the interactive process completed.
+	* Delegate won't be executed if process terminated without user wanting
+	*
+	* @return The delegate.
+	*/
+	FOnInteractiveProcessCompleted& OnCompleted()
+	{
+		return CompletedDelegate;
+	}
+
+	/**
+	* Returns a delegate that is executed when a interactive process produces output.
+	*
+	* @return The delegate.
+	*/
+	FOnInteractiveProcessOutput& OnOutput()
+	{
+		return OutputDelegate;
+	}
+
+	FOnInteractiveProcesOutputArray& OnOutputArray()
+	{
+		return OutputArrayDelegate;
+	}
+
+	/**
+	* Sends the message when process is ready
+	*
+	* @param Message to be sent
+	*/
+	void SendWhenReady(const FString &Message);
+
+	/**
+	* Returns the return code from the exited process
+	*
+	* @return Process return code
+	*/
+	int GetReturnCode() const
+	{
+		return ReturnCode;
+	}
+
+	/**
+	* Cancels the process.
+	*
+	* @param InKillTree Whether to kill the entire process tree when canceling this process.
+	*/
+	void Cancel(bool InKillTree = false)
+	{
+		bCanceling = true;
+		bKillTree = InKillTree;
+	}
+
+	// FRunnable interface
+
+	virtual bool Init() override
+	{
+		return true;
+	}
+
+	virtual uint32 Run() override;
+
+	virtual void Stop() override
+	{
+		Cancel();
+	}
+
+	virtual void Exit() override { }
+
+protected:
+
+	/**
+	* Processes the given output string.
+	*
+	* @param Output The output string to process.
+	*/
+	void ProcessOutput(TArray<uint8> OutputArray);
+
+	/**
+	 * Takes the first message to be sent from MessagesToProcess, if there is one, and sends it to process
+	 */
+	void SendMessageToProcessIf();
+
+private:
+	// Whether the process is being canceled. */
+	bool bCanceling : 1;
+
+	// Whether the window of the process should be hidden. */
+	bool bHidden : 1;
+
+	// Whether to kill the entire process tree when cancelling this process. */
+	bool bKillTree : 1;
+	
+	// How many milliseconds should the process sleep */
+	float SleepTime;
+
+	// Holds the URL of the executable to launch. */
+	FString URL;
+
+	// Holds the command line parameters. */
+	FString Params;
+
+	// Holds the working directory. */
+	FString WorkingDir;
+
+	// Holds the handle to the process. */
+	FProcHandle ProcessHandle;
+
+	// Holds the read pipe of parent process. */
+	void* ReadPipeParent;
+
+	// Holds the write pipe of parent process. */
+	void* WritePipeParent;
+
+	// Holds the read pipe of child process. Should not be used except for testing */
+	void* ReadPipeChild;
+	
+	// Holds the write pipe of child process. Should not be used except for testing */
+	void* WritePipeChild;
+
+	// Holds the thread object. */
+	FRunnableThread* Thread;
+
+	// Holds the name of thread */
+	FString ThreadName;
+
+	// Holds the return code. */
+	int ReturnCode;
+
+	// Holds the time at which the process started. */
+	FDateTime StartTime;
+
+	// Holds the time at which the process ended. */
+	FDateTime EndTime;
+
+	// Holds messages to be written to pipe when ready */
+	TQueue<FString> MessagesToProcess;
+
+	// Holds a delegate that is executed when the process has been canceled. */
+	FSimpleDelegate CanceledDelegate;
+
+	// Holds a delegate that is executed when a interactive process completed. */
+	FOnInteractiveProcessCompleted CompletedDelegate;
+
+	// Holds a delegate that is executed when a interactive process produces output. */
+	FOnInteractiveProcessOutput OutputDelegate;
+
+	FOnInteractiveProcesOutputArray OutputArrayDelegate;
+};


### PR DESCRIPTION
This extends the `RunDumpToFile` to handle LFS pointer files. It first checks if LFS is installed and the file is a pointer file. If it is, then it pipes the output from `git show` in to `git lfs smude` which is the command to retrieve the actual file contents. This is then saved to the same temp file that was previously being used.

If either the file isn't a pointer file or LFS isn't installed then it just outputs the file to the temp file as it did before. 

To get this working - I needed to use `FInteractiveProcess` to both send data in and read data out of `git lfs smudge`. However, this didn't allow the setting of a Working Directory (which seemed to be equired for the LFS command to work). So I duplicated this class and added support for this. Ideally this change would be merged back into UE4. 
