### PR TITLE
Fix issue where locking a file would fail on Linux

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1048,8 +1048,13 @@ bool RunLfsCommand(const FString& InCommand, const FString& InPathToGitBinary, c
 {
 	int32 ReturnCode = -1;
 
-	// First, the git LFS command itself (lfs lock/lfs unlock/lfs locks)
-	FString FullCommand = InCommand;
+	// First, explicitly specify the path to the git directory
+	FString FullCommand = TEXT("-C \"");
+	FullCommand += InRepositoryRoot;
+	FullCommand += TEXT("\" ");
+
+	// Then add the git LFS command itself (lfs lock/lfs unlock/lfs locks)
+	FullCommand += InCommand;
 
 	// Append to the command all the files
 	for(const auto& File : InFiles)


### PR DESCRIPTION
When locking a file (At least on Linux), it would fail with the following message in the log
```
Failed to call git rev-parse --show-toplevel: exit status 128
[2017.11.27-00.38.26:982][724]LogSourceControl: Warning: RunLfsCommand(lfs lock) ReturnCode=2:
```

`git lfs` will error with that message if the current working directory is not within the git directory. For whatever reason passing the directory as `OptionalWorkingDirectory` in `CreateProc` doesn't seem to work.

So I modified the `git` command to take the git directory with the `-C` argument.
Now when locking a file, the plugin will build a command like `git -C "/home/user/Unreal Projects/AwesomeProject lfs lock path/to/file.uasset".