### PR TITLE
Fix git reset command

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -297,7 +297,7 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 	if(AllExistingFiles.Num() > 0)
 	{
 		// reset any changes already added to the index
-		InCommand.bCommandSuccessful = GitSourceControlUtils::RunCommand(TEXT("reset"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, TArray<FString>(), AllExistingFiles, InCommand.InfoMessages, InCommand.ErrorMessages);
+		InCommand.bCommandSuccessful = GitSourceControlUtils::RunCommand(TEXT("reset"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, TArray<FString>({ TEXT("HEAD") }), AllExistingFiles, InCommand.InfoMessages, InCommand.ErrorMessages);
 	}
 	if(OtherThanAddedExistingFiles.Num() > 0)
 	{


### PR DESCRIPTION
I've been using the git plugin available in UE version 4.18.2 (Beta version 1.1). I was unable to delete assets that were added to source control, but not committed. I was also unable to revert them. Renaming them caused duplicate files to appear. After some debugging I found that the plugin was running `git --work-tree=<dir> --git-dir=<dir> reset <file>` (or for short... `git reset <file>`), and this was returning the error "fatal: Invalid object name 'C'." I added "HEAD" to the list of arguments to correct the error. It now runs `git reset HEAD <file>`, and now every file deletion, revert, and rename runs as expected. It seems the line I changed remains unchanged in your current version, and I wanted to share this bugfix. I suspect this might fix your bug #51 as well.