### PR TITLE
Fix missing FUpdateStatus

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -18,6 +18,7 @@
 #include "Logging/MessageLog.h"
 #include "ScopedSourceControlProgress.h"
 #include "SourceControlHelpers.h"
+#include "SourceControlOperations.h"
 #include "IPluginManager.h"
 
 #define LOCTEXT_NAMESPACE "GitSourceControl"


### PR DESCRIPTION
Compiling on 4.20 resulted in a missing "FUpdateStatus" in ControlProvider, so I have added the missing header.