### PR TITLE
Fix: Deleted files were still cached as "added" after "git rm" was ex…

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -295,7 +295,10 @@ void GetMissingVsExistingFiles(const TArray<FString>& InFiles, TArray<FString>& 
 		}
 		else
 		{
-			OutMissingFiles.Add(State->GetFilename());
+			if (State->IsSourceControlled())
+			{
+				OutMissingFiles.Add(State->GetFilename());
+			}
 		}
 	}
 }
@@ -348,7 +351,7 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 	}
 
 	// now update the status of our files
-	GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking, AllExistingFiles, InCommand.ErrorMessages, States);
+	GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking, InCommand.Files, InCommand.ErrorMessages, States);
 
 	return InCommand.bCommandSuccessful;
 }


### PR DESCRIPTION
Deleted files were still cached as "added" after "git rm" was executed. This causes a revert to fail if, for example, you create a new actor in unreal, then delete it. To reproduce:
1. Create a new actor and save it to disk. Unreal should automatically stage it for commit upon saving.
2. Delete the file. Unreal with automatically run "git rm", but fails to update the cache.
3. Click Source Control -> Revert, then OK to the prompt.
4. Unreal complains that the file you deleted doesn't exist and says the revert failed.