### PR TITLE
Implemented support for "Not at Head Revision" in UE4 Git

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlState.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlState.cpp
@@ -62,12 +62,12 @@ TSharedPtr<class ISourceControlRevision, ESPMode::ThreadSafe> FGitSourceControlS
 // @todo add Slate icons for git specific states (NotAtHead vs Conflicted...)
 FName FGitSourceControlState::GetIconName() const
 {
-	// @GFB_CHANGE_BEGIN (Jonas): Icon for not being up-to-date.
+	// Icon for not being up-to-date.
 	if (!IsCurrent())
 	{
 		return FName("Subversion.NotAtHeadRevision");
 	}
-	// @GFB_CHANGE_END
+	
 
 	if(LockState == ELockState::Locked)
 	{
@@ -113,12 +113,12 @@ FName FGitSourceControlState::GetIconName() const
 
 FName FGitSourceControlState::GetSmallIconName() const
 {
-	// @GFB_CHANGE_BEGIN (Jonas): Icon for not being up-to-date.
+	// Icon for not being up-to-date.
 	if (!IsCurrent())
 	{
 		return FName("Subversion.NotAtHeadRevision_Small");
 	}
-	// @GFB_CHANGE_END
+	
 	if(LockState == ELockState::Locked)
 	{
 		return FName("Subversion.CheckedOut_Small");
@@ -163,12 +163,12 @@ FName FGitSourceControlState::GetSmallIconName() const
 
 FText FGitSourceControlState::GetDisplayName() const
 {
-	// @GFB_CHANGE_BEGIN (Jonas): Let the user know that a newer version is available
+	// Let the user know that a newer version is available
 	if (!IsCurrent())
 	{
 		return LOCTEXT("NotCurrent", "Not current");
 	}
-	// @GFB_CHANGE_END
+	
 
 	if(LockState == ELockState::Locked)
 	{
@@ -210,12 +210,12 @@ FText FGitSourceControlState::GetDisplayName() const
 
 FText FGitSourceControlState::GetDisplayTooltip() const
 {
-	// @GFB_CHANGE_BEGIN (Jonas): Let the user know that a newer version is available
+	// Let the user know that a newer version is available
 	if (!IsCurrent())
 	{
 		return LOCTEXT("NotCurrent_Tooltip", "The file(s) are not at the head revision");
 	}
-	// @GFB_CHANGE_END
+	
 
 	if(LockState == ELockState::Locked)
 	{
@@ -288,9 +288,9 @@ bool FGitSourceControlState::CanCheckout() const
 	{
 		return (WorkingCopyState == EWorkingCopyState::Unchanged || WorkingCopyState == EWorkingCopyState::Modified)
 		&& LockState == ELockState::NotLocked
-		// @GFB_CHANGE_BEGIN (Jonas): We don't want to allow checkout if the file is out-of-date, as modifying an out-of-date binary file will most likely result in a merge conflict
+		// We don't want to allow checkout if the file is out-of-date, as modifying an out-of-date binary file will most likely result in a merge conflict
 		&& IsCurrent()
-		// @GFB_CHANGE_END
+		
 		;
 	}
 	else
@@ -322,9 +322,8 @@ bool FGitSourceControlState::IsCheckedOutOther(FString* Who) const
 
 bool FGitSourceControlState::IsCurrent() const
 {
-	// @GFB_CHANGE_BEGIN (Jonas)
 	return !bIsOutdated;
-	// @GFB_CHANGE_END
+	
 }
 
 bool FGitSourceControlState::IsSourceControlled() const

--- a/Source/GitSourceControl/Private/GitSourceControlState.h
+++ b/Source/GitSourceControl/Private/GitSourceControlState.h
@@ -48,9 +48,8 @@ public:
 		, LockState(ELockState::Unknown)
 		, bUsingGitLfsLocking(InUsingLfsLocking)
 		, TimeStamp(0)
-		// @GFB_CHANGE_BEGIN (Jonas)
 		, bIsOutdated(false)
-		// @GFB_CHANGE_END
+		
 	{
 	}
 
@@ -114,7 +113,7 @@ public:
 	/** The timestamp of the last update */
 	FDateTime TimeStamp;
 	
-	// @GFB_CHANGE_BEGIN (Jonas)
+	// For use with FGitSourceControlState::IsCurrent
 	bool bIsOutdated;
-	// @GFB_CHANGE_END
+	
 };

--- a/Source/GitSourceControl/Private/GitSourceControlState.h
+++ b/Source/GitSourceControl/Private/GitSourceControlState.h
@@ -48,6 +48,9 @@ public:
 		, LockState(ELockState::Unknown)
 		, bUsingGitLfsLocking(InUsingLfsLocking)
 		, TimeStamp(0)
+		// @GFB_CHANGE_BEGIN (Jonas)
+		, bIsOutdated(false)
+		// @GFB_CHANGE_END
 	{
 	}
 
@@ -110,4 +113,8 @@ public:
 
 	/** The timestamp of the last update */
 	FDateTime TimeStamp;
+	
+	// @GFB_CHANGE_BEGIN (Jonas)
+	bool bIsOutdated;
+	// @GFB_CHANGE_END
 };

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1071,12 +1071,10 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
 		
 		// First we get the current branch name, since we need origin of current branch
 		Parameters.Empty();
-		TArray<FString> NoPaths;
-		if (RunCommand(TEXT("rev-parse --abbrev-ref HEAD"), InPathToGitBinary, InRepositoryRoot, Parameters, NoPaths, Results, ErrorMessages))
+		FString BranchName;
+		if (GitSourceControlUtils::GetBranchName(InPathToGitBinary, InRepositoryRoot, BranchName))
 		{
-			FString GitBranchName = Results[0];
-
-			FString GitCommand = FString::Printf(TEXT("diff --name-only origin/%s HEAD"), *GitBranchName);
+			FString GitCommand = FString::Printf(TEXT("diff --name-only origin/%s HEAD"), *BranchName);
 
 			const bool bResultDiff = RunCommand(GitCommand, InPathToGitBinary, InRepositoryRoot, Parameters, OnePath, Results, ErrorMessages);
 			OutErrorMessages.Append(ErrorMessages);

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1066,6 +1066,41 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
 		{
 			ParseStatusResults(InPathToGitBinary, InRepositoryRoot, InUsingLfsLocking, Files.Value, LockedFiles, Results, OutStates);
 		}
+		
+		// @GFB_CHANGE_BEGIN (Jonas): Using git diff, we can obtain a list of files that were modified between our current origin and HEAD. Assumes that fetch has been run to get accurate info.
+		Parameters.Empty();
+		const bool bResultDiff = RunCommand(TEXT("diff --name-only origin HEAD"), InPathToGitBinary, InRepositoryRoot, Parameters, OnePath, Results, ErrorMessages);
+		OutErrorMessages.Append(ErrorMessages);
+		if(bResultDiff)
+		{
+			const FDateTime Now = FDateTime::Now();
+			for(const auto& FileName : Results)
+			{
+				const FString AbsoluteFilePath = FPaths::ConvertRelativePathToFull(InRepositoryRoot, FileName);
+				
+				// Check if already exists, and if so, update
+				bool FoundMatch = false;
+				for (INT i = 0; i < OutStates.Num(); i++)
+				{
+					FGitSourceControlState& FileState = OutStates[i];
+
+					if (FileState.LocalFilename != AbsoluteFilePath) continue;
+					
+					FileState.bIsOutdated = true;
+					
+					FoundMatch = true;
+					break;
+				}
+				if (FoundMatch) continue;
+				
+				// If no match, add entry
+				
+				FGitSourceControlState FileState(FileName, InUsingLfsLocking);
+				FileState.TimeStamp = Now;
+				FileState.bIsOutdated = true;
+			}
+		}
+		// @GFB_CHANGE_END
 	}
 
 	return bResults;

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1067,7 +1067,7 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
 			ParseStatusResults(InPathToGitBinary, InRepositoryRoot, InUsingLfsLocking, Files.Value, LockedFiles, Results, OutStates);
 		}
 		
-		// @GFB_CHANGE_BEGIN (Jonas): Using git diff, we can obtain a list of files that were modified between our current origin and HEAD. Assumes that fetch has been run to get accurate info.
+		// Using git diff, we can obtain a list of files that were modified between our current origin and HEAD. Assumes that fetch has been run to get accurate info.
 		
 		// First we get the current branch name, since we need origin of current branch
 		Parameters.Empty();
@@ -1108,7 +1108,7 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
 				}
 			}
 		}
-		// @GFB_CHANGE_END
+		
 	}
 
 	return bResults;


### PR DESCRIPTION
Implemented support for "Not at Head Revision", using `diff --name-only origin HEAD`.

Related issue: #58