### PR TITLE
Fixed a bug introduced with "Not at Head Revision"

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1017,6 +1017,7 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
 	}
 
 	TArray<FString> Results;
+	TArray<FString> NoParameters;
 	TArray<FString> Parameters;
 	Parameters.Add(TEXT("--porcelain"));
 	Parameters.Add(TEXT("--ignored"));
@@ -1067,13 +1068,12 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
 		// Using git diff, we can obtain a list of files that were modified between our current origin and HEAD. Assumes that fetch has been run to get accurate info.
 		
 		// First we get the current branch name, since we need origin of current branch
-		Parameters.Empty();
 		FString BranchName;
 		if (GitSourceControlUtils::GetBranchName(InPathToGitBinary, InRepositoryRoot, BranchName))
 		{
 			FString GitCommand = FString::Printf(TEXT("diff --name-only origin/%s HEAD"), *BranchName);
 
-			const bool bResultDiff = RunCommand(GitCommand, InPathToGitBinary, InRepositoryRoot, Parameters, OnePath, Results, ErrorMessages);
+			const bool bResultDiff = RunCommand(GitCommand, InPathToGitBinary, InRepositoryRoot, NoParameters, OnePath, Results, ErrorMessages);
 			OutErrorMessages.Append(ErrorMessages);
 			if (bResultDiff)
 			{


### PR DESCRIPTION
Fixed a bug introduced with #95 "Not at Head Revision" where the status parameters were being incorrectly wiped. Sorry!

Steps to replicate:
* Add a new asset
* "Mark for Add" the asset (Right-click -> Source Control -> Mark for Add)
* Run Source Control -> Submit to Source Control
* Exit Submit to Source Control (cancel)
* Notice that the status of the asset has been incorrectly removed.
* Run Source Control -> Refresh and notice that the status is now there again.