### PR TITLE
Fix compilation error when using BuildSettingsVersion.V2 in 4.24

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -19,7 +19,7 @@
 #include "ScopedSourceControlProgress.h"
 #include "SourceControlHelpers.h"
 #include "SourceControlOperations.h"
-#include "IPluginManager.h"
+#include "Interfaces/IPluginManager.h"
 
 #define LOCTEXT_NAMESPACE "GitSourceControl"
 


### PR DESCRIPTION
When using the new build settings in 4.24 (BuildSettingsVersion.V2) we need to specify the full relative path in #includes.

This fixes #122.