### PR TITLE
Avoid throwing a warning when checking for git capabilities

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -57,7 +57,7 @@ namespace GitSourceControlUtils
 {
 
 // Launch the Git command line process and extract its results & errors
-static bool RunCommandInternalRaw(const FString& InCommand, const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FString>& InParameters, const TArray<FString>& InFiles, FString& OutResults, FString& OutErrors)
+static bool RunCommandInternalRaw(const FString& InCommand, const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FString>& InParameters, const TArray<FString>& InFiles, FString& OutResults, FString& OutErrors, const int32 ExpectedReturnCode = 0)
 {
 	int32 ReturnCode = 0;
 	FString FullCommand;
@@ -134,20 +134,20 @@ static bool RunCommandInternalRaw(const FString& InCommand, const FString& InPat
 
 //#if UE_BUILD_DEBUG
 	UE_LOG(LogSourceControl, Log, TEXT("RunCommand(%s):\n%s"), *InCommand, *OutResults);
-	if(ReturnCode != 0 || OutErrors.Len() > 0)
+	if(ReturnCode != ExpectedReturnCode || OutErrors.Len() > 0)
 	{
 		UE_LOG(LogSourceControl, Warning, TEXT("RunCommand(%s) ReturnCode=%d:\n%s"), *InCommand, ReturnCode, *OutErrors);
 	}
 //#endif
 
 	// Move push/pull progress information from the error stream to the info stream
-	if(ReturnCode == 0 && OutErrors.Len() > 0)
+	if(ReturnCode == ExpectedReturnCode && OutErrors.Len() > 0)
 	{
 		OutResults.Append(OutErrors);
 		OutErrors.Empty();
 	}
 
-	return ReturnCode == 0;
+	return ReturnCode == ExpectedReturnCode;
 }
 
 // Basic parsing or results & errors from the Git command line process
@@ -396,7 +396,7 @@ void FindGitCapabilities(const FString& InPathToGitBinary, FGitVersion *OutVersi
 {
 	FString InfoMessages;
 	FString ErrorMessages;
-	RunCommandInternalRaw(TEXT("cat-file -h"), InPathToGitBinary, FString(), TArray<FString>(), TArray<FString>(), InfoMessages, ErrorMessages);
+	RunCommandInternalRaw(TEXT("cat-file -h"), InPathToGitBinary, FString(), TArray<FString>(), TArray<FString>(), InfoMessages, ErrorMessages, 129);
 	if (InfoMessages.Contains("--filters"))
 	{
 		OutVersion->bHasCatFileWithFilters = true;


### PR DESCRIPTION
When checking for git availability, we check the cat-file command capabilities with `git cat-file -h`. This command exits with code 129 (expected behavior). This logs a warning in the output log, which when cooking content ends up in the list of warnings at the end.

This pull request adds support for custom return codes in `RunCommandInternalRaw` so that we can pass in an expected non zero code.
Didn't cascade the argument from the higher-level methods for now. The argument defaults to zero to maintain the same behavior.