### PR TITLE
Fix for macOS access to git-lfs in RunDumpToFile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /Binaries/*/*.pdb
 /Binaries/*/*Debug*
+/Binaries/*/*.dylib
+/Binaries/*/*.modules
 /Intermediate

--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -161,10 +161,10 @@ void FGitSourceControlMenu::ReloadPackages(TArray<UPackage*>& InPackagesToReload
 	});
 
 	// Hot-reload the new packages...
-	PackageTools::ReloadPackages(InPackagesToReload);
+	UPackageTools::ReloadPackages(InPackagesToReload);
 
 	// Unload any deleted packages...
-	PackageTools::UnloadPackages(PackagesToUnload);
+	UPackageTools::UnloadPackages(PackagesToUnload);
 }
 
 // Ask the user if he wants to stash any modification and try to unstash them afterward, which could lead to conflicts

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1150,7 +1150,32 @@ bool RunDumpToFile(const FString& InPathToGitBinary, const FString& InRepository
 
 	UE_LOG(LogSourceControl, Log, TEXT("RunDumpToFile: 'git %s'"), *FullCommand);
 
-	FProcHandle ProcessHandle = FPlatformProcess::CreateProc(*InPathToGitBinary, *FullCommand, bLaunchDetached, bLaunchHidden, bLaunchReallyHidden, nullptr, 0, *InRepositoryRoot, PipeWrite);
+    FString PathToGitOrEnvBinary = InPathToGitBinary;
+    #if PLATFORM_MAC
+        // The Cocoa application does not inherit shell environment variables, so add the path expected to have git-lfs to PATH
+        FString PathEnv = FPlatformMisc::GetEnvironmentVariable(TEXT("PATH"));
+        FString GitInstallPath = FPaths::GetPath(InPathToGitBinary);
+
+        TArray<FString> PathArray;
+        PathEnv.ParseIntoArray(PathArray, FPlatformMisc::GetPathVarDelimiter());
+        bool bHasGitInstallPath = false;
+        for (auto Path : PathArray)
+        {
+            if (GitInstallPath.Equals(Path, ESearchCase::CaseSensitive))
+            {
+                bHasGitInstallPath = true;
+                break;
+            }
+        }
+
+        if (!bHasGitInstallPath)
+        {
+            PathToGitOrEnvBinary = FString("/usr/bin/env");
+            FullCommand = FString::Printf(TEXT("PATH=\"%s%s%s\" \"%s\" %s"), *GitInstallPath, FPlatformMisc::GetPathVarDelimiter(), *PathEnv, *InPathToGitBinary, *FullCommand);
+        }
+    #endif
+    
+	FProcHandle ProcessHandle = FPlatformProcess::CreateProc(*PathToGitOrEnvBinary, *FullCommand, bLaunchDetached, bLaunchHidden, bLaunchReallyHidden, nullptr, 0, *InRepositoryRoot, PipeWrite);
 	if(ProcessHandle.IsValid())
 	{
 		FPlatformProcess::Sleep(0.01);


### PR DESCRIPTION
This one took me forever to fix. With this I have git diff working on my Mac.
I also fixed one deprecation warning and update ignores for Mac builds.