### PR TITLE
Fix LFS auto-push failure because out of date, via auto-pull

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -12,6 +12,7 @@
 #include "GitSourceControlModule.h"
 #include "GitSourceControlCommand.h"
 #include "GitSourceControlUtils.h"
+#include "Logging/MessageLog.h"
 
 #define LOCTEXT_NAMESPACE "GitSourceControl"
 
@@ -188,11 +189,72 @@ bool FGitCheckInWorker::Execute(FGitSourceControlCommand& InCommand)
 			// git-lfs: push and unlock files
 			if(InCommand.bUsingGitLfsLocking && InCommand.bCommandSuccessful)
 			{
-				TArray<FString> Parameters2;
-				// TODO Configure origin
-				Parameters2.Add(TEXT("origin"));
-				Parameters2.Add(TEXT("HEAD"));
+                TArray<FString> Parameters2;
+                // TODO Configure origin
+                Parameters2.Add(TEXT("origin"));
+                Parameters2.Add(TEXT("HEAD"));
 				InCommand.bCommandSuccessful = GitSourceControlUtils::RunCommand(TEXT("push"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, Parameters2, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
+				if(!InCommand.bCommandSuccessful)
+				{
+					// if out of date, pull first, then try again
+					bool bWasOutOfDate = false;
+					for (const auto& PushError : InCommand.ErrorMessages)
+					{
+						if (PushError.Contains(TEXT("[rejected]")) && PushError.Contains(TEXT("non-fast-forward")))
+						{
+							// Don't do it during iteration, want to append pull results to InCommand.ErrorMessages
+							bWasOutOfDate = true;
+							break;
+						}
+					}
+					if (bWasOutOfDate)
+					{
+						UE_LOG(LogSourceControl, Log, TEXT("Push failed because we're out of date, pulling automatically to try to resolve"));
+						// Use pull --rebase since that's what the pull command does by default
+						// This requires that we stash if dirty working copy though
+						bool bStashed = false;
+						bool bStashNeeded = false;
+						const TArray<FString> ParametersStatus{"--porcelain --untracked-files=no"};
+						TArray<FString> StatusInfoMessages;
+						TArray<FString> StatusErrorMessages;
+						// Check if there is any modification to the working tree
+						const bool bStatusOk = GitSourceControlUtils::RunCommand(TEXT("status"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, ParametersStatus, TArray<FString>(), StatusInfoMessages, StatusErrorMessages);
+						if ((bStatusOk) && (StatusInfoMessages.Num() > 0))
+						{
+							bStashNeeded = true;
+							const TArray<FString> ParametersStash{ "save \"Stashed by Unreal Engine Git Plugin\"" };
+							bStashed = GitSourceControlUtils::RunCommand(TEXT("stash"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, ParametersStash, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
+							if (!bStashed)
+							{
+								FMessageLog SourceControlLog("SourceControl");
+								SourceControlLog.Warning(LOCTEXT("SourceControlMenu_StashFailed", "Stashing away modifications failed!"));
+								SourceControlLog.Notify();
+							}
+						}
+						if (!bStashNeeded || bStashed)
+						{
+							InCommand.bCommandSuccessful = GitSourceControlUtils::RunCommand(TEXT("pull --rebase"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, TArray<FString>(), TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
+							if (InCommand.bCommandSuccessful)
+							{
+								// Repeat the push
+								InCommand.bCommandSuccessful = GitSourceControlUtils::RunCommand(TEXT("push origin HEAD"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, TArray<FString>(), TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
+							}
+
+							// Succeed or fail, restore the stash
+							if (bStashed)
+							{
+								const TArray<FString> ParametersStashPop{ "pop" };
+								InCommand.bCommandSuccessful = GitSourceControlUtils::RunCommand(TEXT("stash"), InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, ParametersStashPop, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
+								if (!InCommand.bCommandSuccessful)
+								{
+									FMessageLog SourceControlLog("SourceControl");
+									SourceControlLog.Warning(LOCTEXT("SourceControlMenu_UnstashFailed", "Unstashing previously saved modifications failed!"));
+									SourceControlLog.Notify();
+								}
+							}
+						}
+					}
+				}
 				if(InCommand.bCommandSuccessful)
 				{
 					// unlock files: execute the LFS command on relative filenames


### PR DESCRIPTION
There's a common problem if you use the LFS locking mode with more than one person. Because Submit automatically pushes so that it can unlock, if that push fails you're left in a state where you need to resolve it yourself. This means:

1. Pull
2. Push
3. Manually unlock (because Push doesn't do it - I may submit another PR for that)

This is awkward when most of the time the changes are unrelated, git just won't let you push. And since Unlock isn't exposed in UE4 you either have to do it manually, or know that Revert will do it (even though you haven't got any local changes).

In 99% of cases where locking is applied, you could just auto-pull to resolve then try again. So that's what this PR does. In the case of a failed pull, this change:

1. Checks whether the failure was a non-fast forward error
2. If so, it checks whether there are any other modifications, and stashes if needed
3. Performs a pull --rebase (since that's the default in the Pull menu)
4. Re-tries the push
4. Applies the stash again (even in the case of further push failure)

This is a big QoL improvement for us, hope you like it.