### PR TITLE
Actually sleep a little bit so as to not tick too often

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -414,7 +414,7 @@ ECommandResult::Type FGitSourceControlProvider::ExecuteSynchronousCommand(FGitSo
 			Progress.Tick();
 
 			// Sleep so we don't busy-wait so much.
-			FPlatformProcess::Sleep(0.0f);
+			FPlatformProcess::Sleep(0.01f);
 		}
 
 		// always do one more Tick() to make sure the command queue is cleaned up.


### PR DESCRIPTION
This fixes  #139

Progress.Tick() is called too often otherwise and it contains : 
```
// Sync the game thread and the render thread
FSlateApplication::Get().GetRenderer()->Sync();
```

Which seems like a bad thing to call too often.

I think the correct way to do this would be to make this code asynchronous and use the module's tick to tick the other components.