### PR TITLE
Add the option to NOT push after commit on Submit when using LFS

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -187,7 +187,9 @@ bool FGitCheckInWorker::Execute(FGitSourceControlCommand& InCommand)
 			UE_LOG(LogSourceControl, Log, TEXT("commit successful: %s"), *Message);
 
 			// git-lfs: push and unlock files
-			if(InCommand.bUsingGitLfsLocking && InCommand.bCommandSuccessful)
+			if(InCommand.bUsingGitLfsLocking &&
+				InCommand.bCommandSuccessful &&
+				GitSourceControl.AccessSettings().IsPushAfterCommitEnabled())
 			{
                 TArray<FString> Parameters2;
                 // TODO Configure origin

--- a/Source/GitSourceControl/Private/GitSourceControlSettings.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlSettings.cpp
@@ -95,6 +95,7 @@ void FGitSourceControlSettings::LoadSettings()
 	GConfig->GetString(*GitSettingsConstants::SettingsSection, TEXT("BinaryPath"), BinaryPath, IniFile);
 	GConfig->GetBool(*GitSettingsConstants::SettingsSection, TEXT("UsingGitLfsLocking"), bUsingGitLfsLocking, IniFile);
 	GConfig->GetString(*GitSettingsConstants::SettingsSection, TEXT("LfsUserName"), LfsUserName, IniFile);
+	GConfig->GetBool(*GitSettingsConstants::SettingsSection, TEXT("IsPushAfterCommitEnabled"), bIsPushAfterCommitEnabled, IniFile);
 }
 
 void FGitSourceControlSettings::SaveSettings() const
@@ -104,4 +105,5 @@ void FGitSourceControlSettings::SaveSettings() const
 	GConfig->SetString(*GitSettingsConstants::SettingsSection, TEXT("BinaryPath"), *BinaryPath, IniFile);
 	GConfig->SetBool(*GitSettingsConstants::SettingsSection, TEXT("UsingGitLfsLocking"), bUsingGitLfsLocking, IniFile);
 	GConfig->SetString(*GitSettingsConstants::SettingsSection, TEXT("LfsUserName"), *LfsUserName, IniFile);
+	GConfig->SetBool(*GitSettingsConstants::SettingsSection, TEXT("IsPushAfterCommitEnabled"), bIsPushAfterCommitEnabled, IniFile);
 }

--- a/Source/GitSourceControl/Private/GitSourceControlSettings.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlSettings.cpp
@@ -70,6 +70,23 @@ bool FGitSourceControlSettings::SetLfsUserName(const FString& InString)
 	return bChanged;
 }
 
+bool FGitSourceControlSettings::SetIsPushAfterCommitEnabled(bool bInEnabled)
+{
+	FScopeLock ScopeLock(&CriticalSection);
+	const bool bChanged = (bIsPushAfterCommitEnabled != bInEnabled);
+	if (bChanged)
+	{
+		bIsPushAfterCommitEnabled = bInEnabled;
+	}
+	return bChanged;
+}
+
+bool FGitSourceControlSettings::IsPushAfterCommitEnabled() const
+{
+	FScopeLock ScopeLock(&CriticalSection);
+	return bIsPushAfterCommitEnabled;
+}
+
 // This is called at startup nearly before anything else in our module: BinaryPath will then be used by the provider
 void FGitSourceControlSettings::LoadSettings()
 {

--- a/Source/GitSourceControl/Private/GitSourceControlSettings.h
+++ b/Source/GitSourceControl/Private/GitSourceControlSettings.h
@@ -28,6 +28,12 @@ public:
 	/** Set the username used by the Git LFS 2 File Locks server */
 	bool SetLfsUserName(const FString& InString);
 
+	/** Set whether Submit means Commit AND push (default true) */
+	bool SetIsPushAfterCommitEnabled(bool bCond);
+
+	/** Get whether Submit means Commit AND push (default true) */
+	bool IsPushAfterCommitEnabled() const;
+
 	/** Load settings from ini file */
 	void LoadSettings();
 
@@ -46,4 +52,7 @@ private:
 
 	/** Username used by the Git LFS 2 File Locks server */
 	FString LfsUserName;
+
+	/** Does Submit mean Commit AND push */
+	bool bIsPushAfterCommitEnabled = true;
 };

--- a/Source/GitSourceControl/Private/SGitSourceControlSettings.h
+++ b/Source/GitSourceControl/Private/SGitSourceControlSettings.h
@@ -66,6 +66,10 @@ private:
 	void OnCheckedUseGitLfsLocking(ECheckBoxState NewCheckedState);
 	ECheckBoxState IsUsingGitLfsLocking() const;
 	bool GetIsUsingGitLfsLocking() const;
+	
+	void OnIsPushAfterCommitEnabled(ECheckBoxState NewCheckedState);
+	bool GetIsPushAfterCommitEnabled() const;
+	ECheckBoxState IsPushAfterCommitEnabled() const;
 
 	void OnLfsUserNameCommited(const FText& InText, ETextCommit::Type InCommitType);
 	FText GetLfsUserName() const;


### PR DESCRIPTION
Over time I've found it annoying that when using LFS locking, Submit to Source Control always pushes. The reasons I might not want to:

- I have a sequence of commits to make and push each time slows that down
- I know the push will fail because I'm working disconnected or behind the remote branch
- I want to combine asset changes with C++ changes in one commit; without push I can amend the UE commit & add the C++ changes before push

The only reason for always pushing seems to be to unlock files, but I already implemented unlock-on-push in #137, so this is not a hard limit any more. So long as you do the final push in UE the files from the intermediate commits will be unlocked. 

So I've added an extra option in the source control setup dialog to disable auto-pushing. It defaults to the previous behaviour.

