### PR TITLE
Submodule support

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlCommand.h
+++ b/Source/GitSourceControl/Private/GitSourceControlCommand.h
@@ -19,6 +19,11 @@ public:
 	FGitSourceControlCommand(const TSharedRef<class ISourceControlOperation, ESPMode::ThreadSafe>& InOperation, const TSharedRef<class IGitSourceControlWorker, ESPMode::ThreadSafe>& InWorker, const FSourceControlOperationComplete& InOperationCompleteDelegate = FSourceControlOperationComplete() );
 
 	/**
+	 *  Modify the repo root if all selected files are in a plugin subfolder, and the plugin subfolder is a git repo
+	 *  This supports the case where each plugin is a sub module
+	 */
+	void UpdateRepositoryRootIfSubmodule(const TArray<FString>& AbsoluteFilePaths);
+	/**
 	 * This is where the real thread work is done. All work that is done for
 	 * this queued object should be done from within the call to this function.
 	 */

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -254,6 +254,8 @@ ECommandResult::Type FGitSourceControlProvider::Execute( const TSharedRef<ISourc
 
 	FGitSourceControlCommand* Command = new FGitSourceControlCommand(InOperation, Worker.ToSharedRef());
 	Command->Files = AbsoluteFiles;
+	Command->UpdateRepositoryRootIfSubmodule(AbsoluteFiles);
+
 	Command->OperationCompleteDelegate = InOperationCompleteDelegate;
 
 	// fire off operation

--- a/Source/GitSourceControl/Private/GitSourceControlRevision.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlRevision.cpp
@@ -17,8 +17,13 @@ bool FGitSourceControlRevision::Get( FString& InOutFilename ) const
 {
 	FGitSourceControlModule& GitSourceControl = FModuleManager::GetModuleChecked<FGitSourceControlModule>("GitSourceControl");
 	const FString PathToGitBinary = GitSourceControl.AccessSettings().GetBinaryPath();
-	const FString PathToRepositoryRoot = GitSourceControl.GetProvider().GetPathToRepositoryRoot();
+	FString PathToRepositoryRoot = GitSourceControl.GetProvider().GetPathToRepositoryRoot();
 
+	// the repo root can be customised if in a plugin that has it's own repo
+	if (PathToRepoRoot.Len())
+	{
+		PathToRepositoryRoot = PathToRepoRoot;
+	}
 	// if a filename for the temp file wasn't supplied generate a unique-ish one
 	if(InOutFilename.Len() == 0)
 	{
@@ -28,7 +33,6 @@ bool FGitSourceControlRevision::Get( FString& InOutFilename ) const
 		const FString TempFileName = FString::Printf(TEXT("%stemp-%s-%s"), *FPaths::DiffDir(), *CommitId, *FPaths::GetCleanFilename(Filename));
 		InOutFilename = FPaths::ConvertRelativePathToFull(TempFileName);
 	}
-
 	// Diff against the revision
 	const FString Parameter = FString::Printf(TEXT("%s:%s"), *CommitId, *Filename);
 

--- a/Source/GitSourceControl/Private/GitSourceControlRevision.h
+++ b/Source/GitSourceControl/Private/GitSourceControlRevision.h
@@ -70,6 +70,8 @@ public:
 
 	/** The size of the file at this revision */
 	int32 FileSize;
+
+	FString PathToRepoRoot;
 };
 
 /** History composed of the last 100 revisions of the file */

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -82,7 +82,7 @@ FString ChangeRepositoryRootIfSubmodule(const TArray<FString>& AbsoluteFilePaths
 		FString CandidateRepoRoot = PluginsRoot + PluginPart;
 
 		FString IsItUsingGitPath = CandidateRepoRoot + "/.git";
-		if (FPaths::FileExists(IsItUsingGitPath))
+		if (FPaths::FileExists(IsItUsingGitPath) || FPaths::DirectoryExists(IsItUsingGitPath))
 		{
 			Ret = CandidateRepoRoot;
 		}

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -55,7 +55,45 @@ const FString& FGitScopedTempFile::GetFilename() const
 
 namespace GitSourceControlUtils
 {
+FString ChangeRepositoryRootIfSubmodule(const TArray<FString>& AbsoluteFilePaths, const FString& PathToRepositoryRoot)
+{
+	FString Ret = PathToRepositoryRoot;
+	FString PluginsRoot = FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir());
+	// note this is not going to support operations where selected files are both in the root repo and the submodule/plugin's repo
+	int NumPluginFiles = 0;
 
+	for (auto& FilePath : AbsoluteFilePaths)
+	{
+		if (FilePath.Contains(PluginsRoot))
+		{
+			NumPluginFiles++;
+		}
+	}
+	// if all plugins?
+	// modify Source control base path
+	if ((NumPluginFiles == AbsoluteFilePaths.Num()) && (AbsoluteFilePaths.Num() > 0))
+	{
+		FString FullPath = AbsoluteFilePaths[0];
+
+		FString PluginPart = FullPath.Replace(*PluginsRoot, *FString(""));
+		PluginPart = PluginPart.Left(PluginPart.Find("/"));
+
+
+		FString CandidateRepoRoot = PluginsRoot + PluginPart;
+
+		FString IsItUsingGitPath = CandidateRepoRoot + "/.git";
+		if (FPaths::FileExists(IsItUsingGitPath))
+		{
+			Ret = CandidateRepoRoot;
+		}
+	}
+	return Ret;
+}
+FString ChangeRepositoryRootIfSubmodule(const FString& AbsoluteFilePath, const FString& PathToRepositoryRoot)
+{
+	TArray<FString> AbsoluteFilePaths = { AbsoluteFilePath };
+	return ChangeRepositoryRootIfSubmodule(AbsoluteFilePaths, PathToRepositoryRoot);
+}
 // Launch the Git command line process and extract its results & errors
 static bool RunCommandInternalRaw(const FString& InCommand, const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FString>& InParameters, const TArray<FString>& InFiles, FString& OutResults, FString& OutErrors, const int32 ExpectedReturnCode = 0)
 {
@@ -1451,6 +1489,7 @@ bool RunGetHistory(const FString& InPathToGitBinary, const FString& InRepository
 			Revision->FileHash = LsTree.FileHash;
 			Revision->FileSize = LsTree.FileSize;
 		}
+		Revision->PathToRepoRoot = InRepositoryRoot;
 	}
 
 	return bResults;

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.h
@@ -35,6 +35,12 @@ struct FGitVersion;
 
 namespace GitSourceControlUtils
 {
+/**
+*  Returns an updated the repo root if all selected files are in a plugin subfolder, and the plugin subfolder is a git repo
+*  This supports the case where each plugin is a sub module
+*/
+FString ChangeRepositoryRootIfSubmodule(const TArray<FString>& AbsoluteFilePaths, const FString& PathToRepositoryRoot);
+FString ChangeRepositoryRootIfSubmodule(const FString& AbsoluteFilePath, const FString& PathToRepositoryRoot);
 
 /**
  * Find the path to the Git binary, looking into a few places (standalone Git install, and other common tools embedding Git)

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.h
@@ -36,7 +36,7 @@ struct FGitVersion;
 namespace GitSourceControlUtils
 {
 /**
-*  Returns an updated the repo root if all selected files are in a plugin subfolder, and the plugin subfolder is a git repo
+*  Returns an updated repo root if all selected files are in a plugin subfolder, and the plugin subfolder is a git repo
 *  This supports the case where each plugin is a sub module
 * 
 * @param AbsoluteFilePaths		The list of files in the SC operation
@@ -45,10 +45,10 @@ namespace GitSourceControlUtils
 FString ChangeRepositoryRootIfSubmodule(const TArray<FString>& AbsoluteFilePaths, const FString& PathToRepositoryRoot);
 
 /**
-*  Returns an updated the repo root if all selected file is in a plugin subfolder, and the plugin subfolder is a git repo
+*  Returns an updated repo root if all selected file is in a plugin subfolder, and the plugin subfolder is a git repo
 *  This supports the case where each plugin is a sub module
 *
-* @param AbsoluteFilePath		The files in the SC operation
+* @param AbsoluteFilePath		The file in the SC operation
 * @param PathToRepositoryRoot	The original path to the repository root (used by default)
 */
 FString ChangeRepositoryRootIfSubmodule(const FString& AbsoluteFilePath, const FString& PathToRepositoryRoot);

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.h
@@ -38,8 +38,19 @@ namespace GitSourceControlUtils
 /**
 *  Returns an updated the repo root if all selected files are in a plugin subfolder, and the plugin subfolder is a git repo
 *  This supports the case where each plugin is a sub module
+* 
+* @param AbsoluteFilePaths		The list of files in the SC operation
+* @param PathToRepositoryRoot	The original path to the repository root (used by default)
 */
 FString ChangeRepositoryRootIfSubmodule(const TArray<FString>& AbsoluteFilePaths, const FString& PathToRepositoryRoot);
+
+/**
+*  Returns an updated the repo root if all selected file is in a plugin subfolder, and the plugin subfolder is a git repo
+*  This supports the case where each plugin is a sub module
+*
+* @param AbsoluteFilePath		The files in the SC operation
+* @param PathToRepositoryRoot	The original path to the repository root (used by default)
+*/
 FString ChangeRepositoryRootIfSubmodule(const FString& AbsoluteFilePath, const FString& PathToRepositoryRoot);
 
 /**


### PR DESCRIPTION
Basic support for the case where plugins have their own repos/are submodules.

Diffing and history tested along with basic source control operations.

This is not intended to be a comprehensive implementation but enough to get up and running with the built in visual diff tool for blueprints.