### PR TITLE
Make the git console command register dynamically

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlConsole.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlConsole.cpp
@@ -8,15 +8,26 @@
 #include "GitSourceControlModule.h"
 #include "GitSourceControlUtils.h"
 
-// Auto-registered console commands:
-// No re-register on hot reload, and unregistered only once on editor shutdown.
-static FAutoConsoleCommand g_executeGitConsoleCommand(TEXT("git"),
-	TEXT("Git Command Line Interface.\n")
-	TEXT("Run any 'git' command directly from the Unreal Editor Console.\n")
-	TEXT("Type 'git help' to get a command list."),
-	FConsoleCommandWithArgsDelegate::CreateStatic(&GitSourceControlConsole::ExecuteGitConsoleCommand));
+void FGitSourceControlConsole::Register()
+{
+	if (!GitConsoleCommand.IsValid())
+	{
+		GitConsoleCommand = MakeUnique<FAutoConsoleCommand>(
+			TEXT("git"),
+			TEXT("Git Command Line Interface.\n")
+			TEXT("Run any 'git' command directly from the Unreal Editor Console.\n")
+			TEXT("Type 'git help' to get a list of commands."),
+			FConsoleCommandWithArgsDelegate::CreateRaw(this, &FGitSourceControlConsole::ExecuteGitConsoleCommand)
+		);
+	}
+}
 
-void GitSourceControlConsole::ExecuteGitConsoleCommand(const TArray<FString>& a_args)
+void FGitSourceControlConsole::Unregister()
+{
+	GitConsoleCommand.Reset();
+}
+
+void FGitSourceControlConsole::ExecuteGitConsoleCommand(const TArray<FString>& a_args)
 {
 	FGitSourceControlModule& GitSourceControl = FModuleManager::LoadModuleChecked<FGitSourceControlModule>("GitSourceControl");
 	const FString& PathToGitBinary = GitSourceControl.AccessSettings().GetBinaryPath();

--- a/Source/GitSourceControl/Private/GitSourceControlConsole.h
+++ b/Source/GitSourceControl/Private/GitSourceControlConsole.h
@@ -4,15 +4,24 @@
 
 #include "CoreMinimal.h"
 
+class FAutoConsoleCommand;
+
 /**
  * Editor only console commands.
  *
- *  Such commands can be executed from the editor output log window, but also from command line arguments,
+ * Such commands can be executed from the editor output log window, but also from command line arguments,
  * from Editor Blueprints utilities, or from C++ Code using. eg. GEngine->Exec("git status Content/");
  */
-class GitSourceControlConsole
+class FGitSourceControlConsole
 {
 public:
+	void Register();
+	void Unregister();
+
+private:
 	// Git Command Line Interface: Run 'git' commands directly from the Unreal Editor Console.
-	static void ExecuteGitConsoleCommand(const TArray<FString>& a_args);
+	void ExecuteGitConsoleCommand(const TArray<FString>& a_args);
+
+	/** Console command for interacting with 'git' CLI directly */
+	TUniquePtr<FAutoConsoleCommand> GitConsoleCommand;
 };

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -66,6 +66,9 @@ void FGitSourceControlProvider::CheckGitAvailability()
 		if(bGitAvailable)
 		{
 			CheckRepositoryStatus(PathToGitBinary);
+
+			// Register Console Commands (even without a workspace)
+			GitSourceControlConsole.Register();
 		}
 	}
 	else
@@ -109,6 +112,8 @@ void FGitSourceControlProvider::Close()
 	StateCache.Empty();
 	// Remove all extensions to the "Source Control" menu in the Editor Toolbar
 	GitSourceControlMenu.Unregister();
+	// Unregister Console Commands
+	GitSourceControlConsole.Unregister();
 
 	bGitAvailable = false;
 	bGitRepositoryFound = false;

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.h
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.h
@@ -12,6 +12,7 @@
 #include "IGitSourceControlWorker.h"
 #include "GitSourceControlState.h"
 #include "GitSourceControlMenu.h"
+#include "GitSourceControlConsole.h"
 
 class FGitSourceControlCommand;
 
@@ -207,4 +208,7 @@ private:
 
 	/** Source Control Menu Extension */
 	FGitSourceControlMenu GitSourceControlMenu;
+
+	/** Source Control Console commands */
+	FGitSourceControlConsole GitSourceControlConsole;
 };


### PR DESCRIPTION
This is required to prevent it from showing in all projects even when source control is not enabled.